### PR TITLE
Extend TooltipWidget with Image Previewing

### DIFF
--- a/appbase/main/widgets/TooltipWidget.cpp
+++ b/appbase/main/widgets/TooltipWidget.cpp
@@ -35,9 +35,8 @@ TooltipWidget::TooltipWidget(BaseWidget *parent)
                          Qt::X11BypassWindowManagerHint |
                          Qt::BypassWindowManagerHint);
 
-    // FIXME: Empty displayImage_ creates useless padding
+    displayImage_->hide();
     displayImage_->setAlignment(Qt::AlignHCenter);
-    displayImage_->setText(""); // FIXME: not sure if needed
     displayText_->setAlignment(Qt::AlignHCenter);
     displayText_->setText("tooltip text");
     auto layout = new QVBoxLayout();
@@ -89,8 +88,14 @@ void TooltipWidget::setWordWrap(bool wrap)
     this->displayText_->setWordWrap(wrap);
 }
 
+void TooltipWidget::clearImage()
+{
+    this->displayImage_->hide();
+}
+
 void TooltipWidget::setImage(QPixmap image)
 {
+    this->displayImage_->show();
     this->displayImage_->setPixmap(image);
 }
 

--- a/appbase/main/widgets/TooltipWidget.cpp
+++ b/appbase/main/widgets/TooltipWidget.cpp
@@ -22,6 +22,7 @@ TooltipWidget *TooltipWidget::getInstance()
 
 TooltipWidget::TooltipWidget(BaseWidget *parent)
     : BaseWindow(parent, BaseWindow::TopMost)
+    , displayImage_(new QLabel())
     , displayText_(new QLabel())
 {
     this->setStyleSheet("color: #fff; background: #000");
@@ -34,10 +35,14 @@ TooltipWidget::TooltipWidget(BaseWidget *parent)
                          Qt::X11BypassWindowManagerHint |
                          Qt::BypassWindowManagerHint);
 
+    // FIXME: Empty displayImage_ creates useless padding
+    displayImage_->setAlignment(Qt::AlignHCenter);
+    displayImage_->setText(""); // FIXME: not sure if needed
     displayText_->setAlignment(Qt::AlignHCenter);
     displayText_->setText("tooltip text");
     auto layout = new QVBoxLayout();
     layout->setContentsMargins(10, 5, 10, 5);
+    layout->addWidget(displayImage_);
     layout->addWidget(displayText_);
     this->setLayout(layout);
 
@@ -82,6 +87,11 @@ void TooltipWidget::setText(QString text)
 void TooltipWidget::setWordWrap(bool wrap)
 {
     this->displayText_->setWordWrap(wrap);
+}
+
+void TooltipWidget::setImage(QPixmap image)
+{
+    this->displayImage_->setPixmap(image);
 }
 
 void TooltipWidget::changeEvent(QEvent *)

--- a/appbase/main/widgets/TooltipWidget.hpp
+++ b/appbase/main/widgets/TooltipWidget.hpp
@@ -20,6 +20,7 @@ public:
 
     void setText(QString text);
     void setWordWrap(bool wrap);
+    void setImage(QPixmap image);
 
 #ifdef USEWINSDK
     void raise();
@@ -34,6 +35,7 @@ protected:
 private:
     void updateFont();
 
+    QLabel *displayImage_;
     QLabel *displayText_;
     pajlada::Signals::Connection fontChangedConnection_;
 };

--- a/appbase/main/widgets/TooltipWidget.hpp
+++ b/appbase/main/widgets/TooltipWidget.hpp
@@ -20,6 +20,7 @@ public:
 
     void setText(QString text);
     void setWordWrap(bool wrap);
+    void clearImage();
     void setImage(QPixmap image);
 
 #ifdef USEWINSDK


### PR DESCRIPTION
Needed for https://github.com/Chatterino/chatterino2/issues/976

I already have the Emote Tooltip Preview implemented in https://github.com/tsoding/chatterino2/tree/976 but it requires these changes in appbase repo.

Once this PR is merged, I'm gonna make the second one in the main Chatterino 2 repo.